### PR TITLE
Fix plugin base styles

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -135,9 +135,9 @@ module.exports = plugin(
       /* v-2.0 start from here */
       [`.container`]: {
         marginLeft: "auto",
-        marginRIght: "auto",
+        marginRight: "auto",
         paddingLeft: "16px",
-        paddingRIght: "16px",
+        paddingRight: "16px",
       },
 
       [`input[type="checkbox"]:checked ~ .box span`]: {


### PR DESCRIPTION
## Summary
- fix mis-typed CSS property names in plugin

## Testing
- `npm test` *(fails: no test specified)*
- `npm run build-lib` *(fails: Could not resolve entry module ./src/index.js)*

------
https://chatgpt.com/codex/tasks/task_e_687fca5b3b088326873b5c0e14baeebe