### PR TITLE
Update release workflow node version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: 🟢 node
         uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 20
           registry-url: https://registry.npmjs.org
       - name: installing packages
         run: npm ci


### PR DESCRIPTION
## Summary
- update CI to use Node 20

## Testing
- `npm ci`
- `npm publish --access public --dry-run`

------
https://chatgpt.com/codex/tasks/task_e_68810d7a021083268c9a89894b8e6076