### PR TITLE
Add server using bybit-api

### DIFF
--- a/Server/package.json
+++ b/Server/package.json
@@ -18,7 +18,9 @@
     "pack": "webpack --config webpack/webpack.config.js",
     "prepublish": "npm run build:clean",
     "betapublish": "npm publish --tag beta",
-    "lint": "eslint src"
+    "lint": "eslint src",
+    "start": "node src/server.js",
+    "dev": "node src/server.js"
   },
   "author": "Tiago Siebler (https://github.com/tiagosiebler)",
   "contributors": [],

--- a/Server/src/server.js
+++ b/Server/src/server.js
@@ -1,0 +1,87 @@
+require('dotenv').config();
+const express = require('express');
+const cors = require('cors');
+const { RestClientV5 } = require('bybit-api');
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const restClient = new RestClientV5({
+  key: process.env.BYBIT_API_KEY,
+  secret: process.env.BYBIT_API_SECRET,
+  testnet: process.env.BYBIT_TESTNET === 'true',
+});
+
+app.get('/api/klines', async (req, res) => {
+  try {
+    const {
+      symbol = 'BTCUSDT',
+      interval = '1',
+      limit = '200',
+      category = 'linear',
+    } = req.query;
+    const result = await restClient.getKline({
+      category,
+      symbol,
+      interval: interval.toString(),
+      limit: parseInt(limit, 10),
+    });
+    res.json(result);
+  } catch (err) {
+    console.error('Error fetching klines:', err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/api/balance', async (req, res) => {
+  try {
+    const result = await restClient.getWalletBalance({ accountType: 'UNIFIED' });
+    res.json(result);
+  } catch (err) {
+    console.error('Error fetching balance:', err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/api/positions', async (req, res) => {
+  try {
+    const result = await restClient.getPositionInfo({ category: 'linear' });
+    res.json(result);
+  } catch (err) {
+    console.error('Error fetching positions:', err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/api/order', async (req, res) => {
+  try {
+    const { symbol, side, orderType = 'Market', qty, price, leverage, positionIdx } = req.body;
+
+    if (leverage) {
+      await restClient.setLeverage({
+        category: 'linear',
+        symbol,
+        buyLeverage: leverage.toString(),
+        sellLeverage: leverage.toString(),
+      });
+    }
+
+    const result = await restClient.submitOrder({
+      category: 'linear',
+      symbol,
+      side,
+      orderType,
+      qty: qty.toString(),
+      price,
+      positionIdx: positionIdx ?? 0,
+    });
+    res.json(result);
+  } catch (err) {
+    console.error('Error placing order:', err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+const PORT = process.env.PORT || 4000;
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`));


### PR DESCRIPTION
## Summary
- integrate express server with bybit-api in `Server/src/server.js`
- expose endpoints for klines, balance, positions and placing orders
- add start/dev scripts to `Server/package.json`

## Testing
- `npm test` *(fails: Private endpoints require API keys)*

------
https://chatgpt.com/codex/tasks/task_e_688638d90ebc8326bb631daacdc42a5a