### PR TITLE
Enable live Bybit data

### DIFF
--- a/Client/lib/trading-store.ts
+++ b/Client/lib/trading-store.ts
@@ -53,13 +53,7 @@ export const useTradingStore = create<TradingState>((set, get) => ({
   // Actions
   setApiCredentials: (apiKey: string, apiSecret: string) => {
     set({ apiKey, apiSecret })
-    bybitService.config = {
-      ...bybitService.config,
-      apiKey,
-      apiSecret,
-      testnet: get().isTestnet,
-      simulationMode: get().isSimulationMode,
-    }
+    bybitService.setCredentials(apiKey, apiSecret, get().isTestnet)
   },
 
   toggleSimulationMode: () => {

--- a/README.md
+++ b/README.md
@@ -4,11 +4,14 @@ Example trading dashboard using Bybit API.
 
 ## Setup
 
-Create `.env` with API keys:
+Create `.env` with API keys for both the server and the client:
 
 ```
 BYBIT_API_KEY=apikey
 BYBIT_API_SECRET=secret
+NEXT_PUBLIC_BYBIT_API_KEY=apikey
+NEXT_PUBLIC_BYBIT_API_SECRET=secret
+NEXT_PUBLIC_BYBIT_TESTNET=true
 ```
 
 Install packages and start server:

--- a/Server/src/server.js
+++ b/Server/src/server.js
@@ -54,6 +54,32 @@ app.get('/api/positions', async (req, res) => {
   }
 });
 
+app.get('/api/ticker', async (req, res) => {
+  try {
+    const { symbol = 'BTCUSDT', category = 'linear' } = req.query;
+    const result = await restClient.getTickers({ category, symbol });
+    res.json(result);
+  } catch (err) {
+    console.error('Error fetching ticker:', err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/api/orderbook', async (req, res) => {
+  try {
+    const { symbol = 'BTCUSDT', category = 'linear', limit = 25 } = req.query;
+    const result = await restClient.getOrderbook({
+      category,
+      symbol,
+      limit: parseInt(limit, 10),
+    });
+    res.json(result);
+  } catch (err) {
+    console.error('Error fetching orderbook:', err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
 app.post('/api/order', async (req, res) => {
   try {
     const { symbol, side, orderType = 'Market', qty, price, leverage, positionIdx } = req.body;


### PR DESCRIPTION
## Summary
- add credential helper in `BybitService` to initialize websocket/rest clients
- expose env vars to the client
- create API endpoints for ticker and orderbook on the server
- document required env vars

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6886418019688326afd9c3a5e6793d5a