### PR TITLE
Fix websocket subscription for bybit

### DIFF
--- a/Client/lib/bybit-client.ts
+++ b/Client/lib/bybit-client.ts
@@ -184,17 +184,17 @@ export class BybitService {
         if (!this.wsClient) throw new Error("WebSocket client not initialized")
       }
 
-      this.wsClient.subscribe(
+      this.wsClient.subscribeV5(
         symbols.map((symbol) => `tickers.${symbol}`),
-        "v5",
+        "linear",
       )
 
       this.wsClient.on("update", callback)
 
       return () => {
-        this.wsClient?.unsubscribe(
+        this.wsClient?.unsubscribeV5(
           symbols.map((symbol) => `tickers.${symbol}`),
-          "v5",
+          "linear",
         )
       }
     } catch (error) {
@@ -214,11 +214,11 @@ export class BybitService {
         if (!this.wsClient) throw new Error("WebSocket client not initialized")
       }
 
-      this.wsClient.subscribe([`orderbook.25.${symbol}`], "v5")
+      this.wsClient.subscribeV5([`orderbook.25.${symbol}`], "linear")
       this.wsClient.on("update", callback)
 
       return () => {
-        this.wsClient?.unsubscribe([`orderbook.25.${symbol}`], "v5")
+        this.wsClient?.unsubscribeV5([`orderbook.25.${symbol}`], "linear")
       }
     } catch (error) {
       console.error("Error subscribing to orderbook:", error)


### PR DESCRIPTION
## Summary
- use `subscribeV5`/`unsubscribeV5` with `linear` category when subscribing

## Testing
- `npm run build` in `Client`
- `npm test` in `Server` *(fails: Private endpoints require api keys)*

------
https://chatgpt.com/codex/tasks/task_e_68864811adb8832688f2c139b44fa493