### PR TITLE
Add API key validation

### DIFF
--- a/Client/components/api-settings.tsx
+++ b/Client/components/api-settings.tsx
@@ -18,6 +18,7 @@ export function ApiSettings() {
     isTestnet,
     isSimulationMode,
     isConnected,
+    isCheckingCredentials,
     error,
     setApiCredentials,
     toggleSimulationMode,
@@ -103,6 +104,9 @@ export function ApiSettings() {
                 <Shield className="h-4 w-4 mr-2" />
                 API 키 저장
               </Button>
+              {isCheckingCredentials && (
+                <p className="text-sm text-muted-foreground mt-2">API 키 확인 중...</p>
+              )}
             </div>
           )}
 
@@ -115,7 +119,13 @@ export function ApiSettings() {
                 <AlertTriangle className="h-5 w-5 text-yellow-600" />
               )}
               <div>
-                <p className="font-medium">{isConnected ? "연결됨" : "연결 안됨"}</p>
+                <p className="font-medium">
+                  {isCheckingCredentials
+                    ? "확인 중"
+                    : isConnected
+                    ? "연결됨"
+                    : "연결 안됨"}
+                </p>
                 <p className="text-sm text-muted-foreground">
                   {isSimulationMode ? "시뮬레이션 모드" : isTestnet ? "테스트넷" : "메인넷"}
                 </p>

--- a/Client/lib/bybit-client.ts
+++ b/Client/lib/bybit-client.ts
@@ -43,6 +43,25 @@ export class BybitService {
     }
   }
 
+  /** Validate that the provided credentials can make authenticated requests */
+  async validateCredentials(apiKey: string, apiSecret: string, testnet = true) {
+    try {
+      const res = await fetch('/api/validate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ apiKey, apiSecret, testnet }),
+      })
+      const data = await res.json()
+      if (!res.ok || !data.valid) {
+        throw new Error(data.error || 'Invalid credentials')
+      }
+      return true
+    } catch (err) {
+      console.error('API credential validation failed:', err)
+      throw err
+    }
+  }
+
   private initializeClients() {
     try {
       // Clean up previous clients if they exist

--- a/Server/src/server.js
+++ b/Server/src/server.js
@@ -80,6 +80,20 @@ app.get('/api/orderbook', async (req, res) => {
   }
 });
 
+// Validate API credentials by attempting a private request
+app.post('/api/validate', async (req, res) => {
+  const { apiKey, apiSecret, testnet = true } = req.body;
+  const client = new RestClientV5({ key: apiKey, secret: apiSecret, testnet });
+  try {
+    await client.getWalletBalance({ accountType: 'UNIFIED' });
+    console.log('API credentials validated successfully');
+    res.json({ valid: true });
+  } catch (err) {
+    console.log('API credential validation failed:', err.message);
+    res.status(400).json({ valid: false, error: err.message });
+  }
+});
+
 app.post('/api/order', async (req, res) => {
   try {
     const { symbol, side, orderType = 'Market', qty, price, leverage, positionIdx } = req.body;


### PR DESCRIPTION
## Summary
- validate API credentials on the server and log result
- expose validation in `bybit-client`
- verify credentials when saving in zustand store
- show checking state in API settings UI

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint` *(failed: interactive prompt)*
- `npm run build`
- `npm test` *(failed: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68864b3072bc83269786d14dcbb07524