### PR TITLE
Fix env loading for root .env

### DIFF
--- a/Client/next.config.mjs
+++ b/Client/next.config.mjs
@@ -1,3 +1,9 @@
+import { config } from 'dotenv'
+import { resolve } from 'path'
+
+// Load environment variables from the project root .env file
+config({ path: resolve(__dirname, '..', '.env') })
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   eslint: {

--- a/README.md
+++ b/README.md
@@ -4,14 +4,16 @@ Example trading dashboard using Bybit API.
 
 ## Setup
 
-Create `.env` with API keys for both the server and the client:
+Create `.env` in the project root with API keys for both the server and the client.
+The client configuration reads this file automatically:
 
 ```
 BYBIT_API_KEY=apikey
 BYBIT_API_SECRET=secret
 NEXT_PUBLIC_BYBIT_API_KEY=apikey
 NEXT_PUBLIC_BYBIT_API_SECRET=secret
-NEXT_PUBLIC_BYBIT_TESTNET=true
+# Set to "true" to use Bybit testnet, otherwise "false" for mainnet
+NEXT_PUBLIC_BYBIT_TESTNET=false
 ```
 
 Install packages and start server:

--- a/Server/src/server.js
+++ b/Server/src/server.js
@@ -1,4 +1,6 @@
-require('dotenv').config();
+const path = require('path');
+// Always load env variables from the project root
+require('dotenv').config({ path: path.resolve(__dirname, '../..', '.env') });
 const express = require('express');
 const cors = require('cors');
 const { RestClientV5 } = require('bybit-api');


### PR DESCRIPTION
## Summary
- load root `.env` from Client configuration
- document env file usage and default to mainnet
- ensure server loads environment from project root

## Testing
- `npm install` *(in Server)*
- `npm test` *(fails: Private endpoints require api keys; network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68865a5f71648326a68efa21d369cd10