### PR TITLE
Fix realtime chart data update

### DIFF
--- a/Client/components/enhanced-trading-chart.tsx
+++ b/Client/components/enhanced-trading-chart.tsx
@@ -1,11 +1,11 @@
-"use client"
+"use client";
 
-import { useState, useEffect } from "react"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
-import { useTradingStore } from "@/lib/trading-store"
+import { useState, useEffect, useRef } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { useTradingStore } from "@/lib/trading-store";
 import {
   ComposedChart,
   Line,
@@ -17,73 +17,88 @@ import {
   ResponsiveContainer,
   ReferenceLine,
   Area,
-} from "recharts"
-import { TrendingUp, TrendingDown, BarChart3, LineChart } from "lucide-react"
+} from "recharts";
+import { TrendingUp, TrendingDown, BarChart3, LineChart } from "lucide-react";
 
 interface ChartData {
-  time: string
-  timestamp: number
-  open: number
-  high: number
-  low: number
-  close: number
-  volume: number
-  rsi: number
-  bb_upper: number
-  bb_middle: number
-  bb_lower: number
-  macd: number
-  macd_signal: number
-  macd_histogram: number
+  time: string;
+  timestamp: number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+  rsi: number;
+  bb_upper: number;
+  bb_middle: number;
+  bb_lower: number;
+  macd: number;
+  macd_signal: number;
+  macd_histogram: number;
 }
 
 interface EnhancedTradingChartProps {
-  symbol: string
+  symbol: string;
 }
 
 export function EnhancedTradingChart({ symbol }: EnhancedTradingChartProps) {
-  const { tickers, isSimulationMode } = useTradingStore()
-  const [chartData, setChartData] = useState<ChartData[]>([])
-  const [timeframe, setTimeframe] = useState("1h")
-  const [chartType, setChartType] = useState<"candlestick" | "line">("candlestick")
+  const { tickers, isSimulationMode } = useTradingStore();
+  const [chartData, setChartData] = useState<ChartData[]>([]);
+  const [timeframe, setTimeframe] = useState("1h");
+  const [chartType, setChartType] = useState<"candlestick" | "line">(
+    "candlestick",
+  );
   const [showIndicators, setShowIndicators] = useState({
     rsi: true,
     bollinger: true,
     macd: false,
     volume: true,
-  })
+  });
+  const lastValidPrice = useRef(0);
 
-  const currentTicker = tickers[symbol]
-  const currentPrice = currentTicker?.lastPrice ? Number.parseFloat(currentTicker.lastPrice) : 0
-  const priceChange = currentTicker?.price24hPcnt ? Number.parseFloat(currentTicker.price24hPcnt) : 0
+  const currentTicker = tickers[symbol];
+  const currentPrice = currentTicker?.lastPrice
+    ? Number.parseFloat(currentTicker.lastPrice)
+    : 0;
+  const priceChange = currentTicker?.price24hPcnt
+    ? Number.parseFloat(currentTicker.price24hPcnt)
+    : 0;
 
-  // Generate enhanced chart data
+  // Preserve the last valid price so the chart doesn't jump to zero when
+  // the websocket misses a tick.
+  useEffect(() => {
+    if (currentPrice > 0) {
+      lastValidPrice.current = currentPrice;
+    }
+  }, [currentPrice]);
+
+  // Generate enhanced chart data whenever the symbol changes
   useEffect(() => {
     const generateEnhancedChartData = () => {
-      const data: ChartData[] = []
-      let basePrice = currentPrice || 43250
+      const data: ChartData[] = [];
+      let basePrice = lastValidPrice.current || currentPrice || 43250;
 
       for (let i = 0; i < 200; i++) {
-        const timestamp = Date.now() - (200 - i) * 60 * 60 * 1000
-        const time = new Date(timestamp).toLocaleTimeString()
+        const timestamp = Date.now() - (200 - i) * 60 * 60 * 1000;
+        const time = new Date(timestamp).toLocaleTimeString();
 
-        const change = (Math.random() - 0.5) * 0.02
-        const open = basePrice
-        const close = basePrice * (1 + change)
-        const high = Math.max(open, close) * (1 + Math.random() * 0.01)
-        const low = Math.min(open, close) * (1 - Math.random() * 0.01)
-        const volume = Math.random() * 1000000
+        const change = (Math.random() - 0.5) * 0.02;
+        const open = basePrice;
+        const close = basePrice * (1 + change);
+        const high = Math.max(open, close) * (1 + Math.random() * 0.01);
+        const low = Math.min(open, close) * (1 - Math.random() * 0.01);
+        const volume = Math.random() * 1000000;
 
         // Technical indicators (simplified calculations)
-        const rsi = 30 + Math.random() * 40
-        const bb_middle = close
-        const bb_upper = bb_middle * 1.02
-        const bb_lower = bb_middle * 0.98
+        const rsi = 30 + Math.random() * 40;
+        const bb_middle = close;
+        const bb_upper = bb_middle * 1.02;
+        const bb_lower = bb_middle * 0.98;
 
         // MACD (simplified)
-        const macd = (Math.random() - 0.5) * 100
-        const macd_signal = macd * 0.8
-        const macd_histogram = macd - macd_signal
+        const macd = (Math.random() - 0.5) * 100;
+        const macd_signal = macd * 0.8;
+        const macd_histogram = macd - macd_signal;
 
         data.push({
           time,
@@ -100,62 +115,67 @@ export function EnhancedTradingChart({ symbol }: EnhancedTradingChartProps) {
           macd,
           macd_signal,
           macd_histogram,
-        })
+        });
 
-        basePrice = close
+        basePrice = close;
       }
 
-      return data
-    }
+      return data;
+    };
 
-    setChartData(generateEnhancedChartData())
+    setChartData(generateEnhancedChartData());
+  }, [symbol]);
 
-    // Real-time updates
+  // Real-time updates
+  useEffect(() => {
     const interval = setInterval(() => {
-      if (currentPrice > 0) {
+      const price = currentPrice > 0 ? currentPrice : lastValidPrice.current;
+      if (price > 0) {
         setChartData((prevData) => {
-          const newData = [...prevData]
-          const lastItem = newData[newData.length - 1]
-          const change = (Math.random() - 0.5) * 0.005
-
+          const newData = [...prevData];
+          const lastItem = newData[newData.length - 1];
           const newItem: ChartData = {
             ...lastItem,
             time: new Date().toLocaleTimeString(),
             timestamp: Date.now(),
-            close: currentPrice,
-            high: Math.max(lastItem.high, currentPrice),
-            low: Math.min(lastItem.low, currentPrice),
+            close: price,
+            high: Math.max(lastItem.high, price),
+            low: Math.min(lastItem.low, price),
             volume: Math.random() * 1000000,
-            rsi: Math.max(0, Math.min(100, lastItem.rsi + (Math.random() - 0.5) * 10)),
+            rsi: Math.max(
+              0,
+              Math.min(100, lastItem.rsi + (Math.random() - 0.5) * 10),
+            ),
             macd: (Math.random() - 0.5) * 100,
-          }
+          };
 
-          newItem.bb_middle = newItem.close
-          newItem.bb_upper = newItem.bb_middle * 1.02
-          newItem.bb_lower = newItem.bb_middle * 0.98
-          newItem.macd_signal = newItem.macd * 0.8
-          newItem.macd_histogram = newItem.macd - newItem.macd_signal
+          newItem.bb_middle = newItem.close;
+          newItem.bb_upper = newItem.bb_middle * 1.02;
+          newItem.bb_lower = newItem.bb_middle * 0.98;
+          newItem.macd_signal = newItem.macd * 0.8;
+          newItem.macd_histogram = newItem.macd - newItem.macd_signal;
 
-          newData.push(newItem)
-          return newData.slice(-200)
-        })
+          newData.push(newItem);
+          return newData.slice(-200);
+        });
       }
-    }, 3000)
+    }, 3000);
 
-    return () => clearInterval(interval)
-  }, [symbol, currentPrice])
+    return () => clearInterval(interval);
+  }, [symbol, currentPrice]);
 
   const MainChart = ({ data }: { data: ChartData[] }) => (
     <ResponsiveContainer width="100%" height={400}>
-      <ComposedChart data={data}>
+      <ComposedChart data={data} isAnimationActive={false}>
         <CartesianGrid strokeDasharray="3 3" />
         <XAxis dataKey="time" />
         <YAxis yAxisId="price" orientation="right" />
         {showIndicators.volume && <YAxis yAxisId="volume" orientation="left" />}
         <Tooltip
           formatter={(value, name) => {
-            if (name === "volume") return [Number(value).toLocaleString(), "거래량"]
-            return [`$${Number(value).toFixed(2)}`, name]
+            if (name === "volume")
+              return [Number(value).toLocaleString(), "거래량"];
+            return [`$${Number(value).toFixed(2)}`, name];
           }}
         />
 
@@ -194,44 +214,80 @@ export function EnhancedTradingChart({ symbol }: EnhancedTradingChartProps) {
 
         {/* Price Line/Candlestick */}
         {chartType === "line" ? (
-          <Line yAxisId="price" type="monotone" dataKey="close" stroke="#8b5cf6" strokeWidth={2} dot={false} />
+          <Line
+            yAxisId="price"
+            type="monotone"
+            dataKey="close"
+            stroke="#8b5cf6"
+            strokeWidth={2}
+            dot={false}
+          />
         ) : (
-          <Line yAxisId="price" type="monotone" dataKey="close" stroke="#8b5cf6" strokeWidth={2} dot={false} />
+          <Line
+            yAxisId="price"
+            type="monotone"
+            dataKey="close"
+            stroke="#8b5cf6"
+            strokeWidth={2}
+            dot={false}
+          />
         )}
 
         {/* Volume */}
-        {showIndicators.volume && <Bar yAxisId="volume" dataKey="volume" fill="#e5e7eb" opacity={0.3} />}
+        {showIndicators.volume && (
+          <Bar yAxisId="volume" dataKey="volume" fill="#e5e7eb" opacity={0.3} />
+        )}
       </ComposedChart>
     </ResponsiveContainer>
-  )
+  );
 
   const RSIChart = ({ data }: { data: ChartData[] }) => (
     <ResponsiveContainer width="100%" height={120}>
-      <ComposedChart data={data}>
+      <ComposedChart data={data} isAnimationActive={false}>
         <CartesianGrid strokeDasharray="3 3" />
         <XAxis dataKey="time" />
         <YAxis domain={[0, 100]} />
-        <Tooltip formatter={(value) => [`${Number(value).toFixed(1)}`, "RSI"]} />
+        <Tooltip
+          formatter={(value) => [`${Number(value).toFixed(1)}`, "RSI"]}
+        />
         <ReferenceLine y={70} stroke="#ef4444" strokeDasharray="2 2" />
         <ReferenceLine y={30} stroke="#22c55e" strokeDasharray="2 2" />
-        <Area type="monotone" dataKey="rsi" stroke="#f59e0b" fill="#f59e0b" fillOpacity={0.1} />
+        <Area
+          type="monotone"
+          dataKey="rsi"
+          stroke="#f59e0b"
+          fill="#f59e0b"
+          fillOpacity={0.1}
+        />
       </ComposedChart>
     </ResponsiveContainer>
-  )
+  );
 
   const MACDChart = ({ data }: { data: ChartData[] }) => (
     <ResponsiveContainer width="100%" height={120}>
-      <ComposedChart data={data}>
+      <ComposedChart data={data} isAnimationActive={false}>
         <CartesianGrid strokeDasharray="3 3" />
         <XAxis dataKey="time" />
         <YAxis />
         <Tooltip />
-        <Line type="monotone" dataKey="macd" stroke="#3b82f6" strokeWidth={2} dot={false} />
-        <Line type="monotone" dataKey="macd_signal" stroke="#ef4444" strokeWidth={2} dot={false} />
+        <Line
+          type="monotone"
+          dataKey="macd"
+          stroke="#3b82f6"
+          strokeWidth={2}
+          dot={false}
+        />
+        <Line
+          type="monotone"
+          dataKey="macd_signal"
+          stroke="#ef4444"
+          strokeWidth={2}
+          dot={false}
+        />
         <Bar dataKey="macd_histogram" fill="#6b7280" opacity={0.6} />
       </ComposedChart>
     </ResponsiveContainer>
-  )
+  );
 
   return (
     <Card>
@@ -246,9 +302,17 @@ export function EnhancedTradingChart({ symbol }: EnhancedTradingChartProps) {
             </CardTitle>
             {currentPrice > 0 && (
               <div className="flex items-center gap-2">
-                <span className="text-2xl font-bold">${currentPrice.toFixed(2)}</span>
-                <div className={`flex items-center gap-1 ${priceChange >= 0 ? "text-green-600" : "text-red-600"}`}>
-                  {priceChange >= 0 ? <TrendingUp className="h-4 w-4" /> : <TrendingDown className="h-4 w-4" />}
+                <span className="text-2xl font-bold">
+                  ${currentPrice.toFixed(2)}
+                </span>
+                <div
+                  className={`flex items-center gap-1 ${priceChange >= 0 ? "text-green-600" : "text-red-600"}`}
+                >
+                  {priceChange >= 0 ? (
+                    <TrendingUp className="h-4 w-4" />
+                  ) : (
+                    <TrendingDown className="h-4 w-4" />
+                  )}
                   <span>
                     {priceChange >= 0 ? "+" : ""}
                     {(priceChange * 100).toFixed(2)}%
@@ -292,28 +356,39 @@ export function EnhancedTradingChart({ symbol }: EnhancedTradingChartProps) {
           <Button
             variant={showIndicators.bollinger ? "default" : "outline"}
             size="sm"
-            onClick={() => setShowIndicators((prev) => ({ ...prev, bollinger: !prev.bollinger }))}
+            onClick={() =>
+              setShowIndicators((prev) => ({
+                ...prev,
+                bollinger: !prev.bollinger,
+              }))
+            }
           >
             볼린저 밴드
           </Button>
           <Button
             variant={showIndicators.rsi ? "default" : "outline"}
             size="sm"
-            onClick={() => setShowIndicators((prev) => ({ ...prev, rsi: !prev.rsi }))}
+            onClick={() =>
+              setShowIndicators((prev) => ({ ...prev, rsi: !prev.rsi }))
+            }
           >
             RSI
           </Button>
           <Button
             variant={showIndicators.macd ? "default" : "outline"}
             size="sm"
-            onClick={() => setShowIndicators((prev) => ({ ...prev, macd: !prev.macd }))}
+            onClick={() =>
+              setShowIndicators((prev) => ({ ...prev, macd: !prev.macd }))
+            }
           >
             MACD
           </Button>
           <Button
             variant={showIndicators.volume ? "default" : "outline"}
             size="sm"
-            onClick={() => setShowIndicators((prev) => ({ ...prev, volume: !prev.volume }))}
+            onClick={() =>
+              setShowIndicators((prev) => ({ ...prev, volume: !prev.volume }))
+            }
           >
             거래량
           </Button>
@@ -342,5 +417,5 @@ export function EnhancedTradingChart({ symbol }: EnhancedTradingChartProps) {
         </div>
       </CardContent>
     </Card>
-  )
+  );
 }

--- a/Client/lib/trading-store.ts
+++ b/Client/lib/trading-store.ts
@@ -1,40 +1,40 @@
-"use client"
+"use client";
 
-import { create } from "zustand"
-import { bybitService } from "./bybit-client"
+import { create } from "zustand";
+import { bybitService } from "./bybit-client";
 
 interface TradingState {
   // API Configuration
-  apiKey: string
-  apiSecret: string
-  isTestnet: boolean
-  isSimulationMode: boolean
+  apiKey: string;
+  apiSecret: string;
+  isTestnet: boolean;
+  isSimulationMode: boolean;
 
   // Market Data
-  tickers: Record<string, any>
-  orderbooks: Record<string, any>
+  tickers: Record<string, any>;
+  orderbooks: Record<string, any>;
 
   // Account Data
-  balance: any
-  positions: any[]
-  orders: any[]
+  balance: any;
+  positions: any[];
+  orders: any[];
 
   // UI State
-  selectedSymbol: string
-  isConnected: boolean
-  error: string | null
+  selectedSymbol: string;
+  isConnected: boolean;
+  error: string | null;
 
-  isCheckingCredentials: boolean
+  isCheckingCredentials: boolean;
 
   // Actions
-  setApiCredentials: (apiKey: string, apiSecret: string) => Promise<void>
-  toggleSimulationMode: () => void
-  setSelectedSymbol: (symbol: string) => void
-  updateTicker: (symbol: string, data: any) => void
-  updateOrderbook: (symbol: string, data: any) => void
-  refreshAccountData: () => Promise<void>
-  placeOrder: (orderParams: any) => Promise<any>
-  setError: (error: string | null) => void
+  setApiCredentials: (apiKey: string, apiSecret: string) => Promise<void>;
+  toggleSimulationMode: () => void;
+  setSelectedSymbol: (symbol: string) => void;
+  updateTicker: (symbol: string, data: any) => void;
+  updateOrderbook: (symbol: string, data: any) => void;
+  refreshAccountData: () => Promise<void>;
+  placeOrder: (orderParams: any) => Promise<any>;
+  setError: (error: string | null) => void;
 }
 
 export const useTradingStore = create<TradingState>((set, get) => ({
@@ -55,61 +55,82 @@ export const useTradingStore = create<TradingState>((set, get) => ({
 
   // Actions
   setApiCredentials: async (apiKey: string, apiSecret: string) => {
-    set({ apiKey, apiSecret, isCheckingCredentials: true })
-    bybitService.setCredentials(apiKey, apiSecret, get().isTestnet)
+    set({ apiKey, apiSecret, isCheckingCredentials: true });
+    bybitService.setCredentials(apiKey, apiSecret, get().isTestnet);
 
     try {
-      await bybitService.validateCredentials(apiKey, apiSecret, get().isTestnet)
-      set({ isConnected: true, isCheckingCredentials: false, error: null })
+      await bybitService.validateCredentials(
+        apiKey,
+        apiSecret,
+        get().isTestnet,
+      );
+      set({ isConnected: true, isCheckingCredentials: false, error: null });
     } catch (err) {
-      set({ isConnected: false, isCheckingCredentials: false, error: err instanceof Error ? err.message : 'Invalid credentials' })
+      set({
+        isConnected: false,
+        isCheckingCredentials: false,
+        error: err instanceof Error ? err.message : "Invalid credentials",
+      });
     }
   },
 
   toggleSimulationMode: () => {
-    const newMode = !get().isSimulationMode
-    set({ isSimulationMode: newMode })
-    bybitService.setSimulationMode(newMode)
+    const newMode = !get().isSimulationMode;
+    set({ isSimulationMode: newMode });
+    bybitService.setSimulationMode(newMode);
   },
 
   setSelectedSymbol: (symbol: string) => {
-    set({ selectedSymbol: symbol })
+    set({ selectedSymbol: symbol });
   },
 
   updateTicker: (symbol: string, data: any) => {
-    set((state) => ({
-      tickers: { ...state.tickers, [symbol]: data },
-    }))
+    set((state) => {
+      // Ignore updates that contain an empty price which can occur when
+      // the websocket momentarily fails to provide data. Keeping the
+      // previous ticker prevents the UI from showing zero values.
+      const lastPrice = Number(data?.lastPrice);
+      if (!data || !data.lastPrice || lastPrice === 0) {
+        return { tickers: { ...state.tickers } };
+      }
+
+      return {
+        tickers: { ...state.tickers, [symbol]: data },
+      };
+    });
   },
 
   updateOrderbook: (symbol: string, data: any) => {
     set((state) => ({
       orderbooks: { ...state.orderbooks, [symbol]: data },
-    }))
+    }));
   },
 
   refreshAccountData: async () => {
     try {
-      const [balance, positions] = await Promise.all([bybitService.getAccountBalance(), bybitService.getPositions()])
+      const [balance, positions] = await Promise.all([
+        bybitService.getAccountBalance(),
+        bybitService.getPositions(),
+      ]);
 
-      set({ balance, positions, error: null })
+      set({ balance, positions, error: null });
     } catch (error) {
-      set({ error: error instanceof Error ? error.message : "Unknown error" })
+      set({ error: error instanceof Error ? error.message : "Unknown error" });
     }
   },
 
   placeOrder: async (orderParams: any) => {
     try {
-      const result = await bybitService.placeOrder(orderParams)
-      get().refreshAccountData() // Refresh after order
-      return result
+      const result = await bybitService.placeOrder(orderParams);
+      get().refreshAccountData(); // Refresh after order
+      return result;
     } catch (error) {
-      set({ error: error instanceof Error ? error.message : "Order failed" })
-      throw error
+      set({ error: error instanceof Error ? error.message : "Order failed" });
+      throw error;
     }
   },
 
   setError: (error: string | null) => {
-    set({ error })
+    set({ error });
   },
-}))
+}));


### PR DESCRIPTION
## Summary
- ignore zero price updates from websocket
- preserve last valid price for smoother chart updates
- update realtime charting logic to append data instead of recreating
- disable chart animations for incremental updates

## Testing
- `npx prettier -w Client/lib/trading-store.ts Client/components/enhanced-trading-chart.tsx`
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_6886dcc94b788326849e3b8861813b1b