### PR TITLE
Add GPT coin analysis button

### DIFF
--- a/Client/lib/bybit-client.ts
+++ b/Client/lib/bybit-client.ts
@@ -187,6 +187,25 @@ export class BybitService {
     }
   }
 
+  async getGptAnalysis(data: any) {
+    try {
+      const res = await fetch(`${SERVER_URL}/api/gpt`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      })
+      if (!res.ok) {
+        const message = await res.text()
+        throw new Error(`Server error ${res.status}: ${message}`)
+      }
+      const result = await res.json()
+      return result.text as string
+    } catch (error) {
+      console.error('Error fetching GPT analysis:', error)
+      throw error
+    }
+  }
+
   subscribeToTickers(symbols: string[], callback: (data: any) => void) {
     if (this.isSimulation) {
       return this.simulateTickerData(symbols, callback)

--- a/Server/src/server.js
+++ b/Server/src/server.js
@@ -2,6 +2,7 @@ require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
 const { RestClientV5 } = require('bybit-api');
+const axios = require('axios');
 
 const app = express();
 app.use(cors());
@@ -145,6 +146,46 @@ app.post('/api/order', async (req, res) => {
   } catch (err) {
     console.error('Error placing order:', err);
     res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/api/gpt', async (req, res) => {
+  try {
+    const coinInfo = req.body;
+    const prompt =
+      '당신은 고도로 숙련된 트레이더이자 차트 분석 전문가입니다.\n\n' +
+      `${JSON.stringify(coinInfo)}\n\n` +
+      '모두 RSI 지표, 볼린저밴드, 캔들 패턴이 포함되어 있습니다.\n\n' +
+      '### 분석 요청 사항:\n' +
+      '1. 현재 시점에서의 최적 포지션을 선택해주세요:\n   - 매수 (Long) / 매도 (Short) / 보류 (No Trade)\n' +
+      '2. 선택한 포지션이 적절한 이유를 RSI, 볼린저밴드, 캔들 패턴 기반으로 설명해주세요.\n' +
+      '3. 적절한 레버리지 (1x ~ 50x) 를 제안해주세요.\n' +
+      '4. 진입 시점 기준:\n   - **익절가와 예상 수익률(%)**\n   - **손절가와 예상 손실률(%)**\n\n' +
+      '### 응답 형식 (꼭 아래 구조를 따라주세요):\n---\n📈 **포지션 추천:** 매수 / 매도 / 보류\n🔁 **추천 레버리지:** X배\n🎯 **익절가 및 예상 수익률:** $XX / +XX%\n🛑 **손절가 및 예상 손실률:** $XX / -XX%\n📊 **분석 근거:**\n- RSI 상태 (과매수/과매도 여부)\n- 볼린저밴드 위치 (상단 돌파 / 하단 이탈 등)\n- 캔들 패턴 해석 (반전/지속 가능성)\n- 1분, 5분, 15분봉 간 흐름 일치 여부\n\n모든 수치는 전략적 트레이딩 의사결정 보조용입니다. 정확한 근거 기반 판단만 제시해주세요.';
+
+    const response = await axios.post(
+      'https://api.openai.com/v1/chat/completions',
+      {
+        model: 'gpt-4o',
+        temperature: 0.3,
+        messages: [
+          { role: 'user', content: prompt },
+        ],
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+
+    const text = response.data.choices?.[0]?.message?.content || '';
+    console.log('GPT Response:', text);
+    res.json({ text });
+  } catch (err) {
+    console.error('Error fetching GPT analysis:', err.response?.data || err.message);
+    res.status(500).json({ error: 'Failed to fetch GPT analysis' });
   }
 });
 


### PR DESCRIPTION
## Summary
- integrate GPT coin analysis endpoint on server
- add `getGptAnalysis` helper to bybit client
- show "GPT에 이 코인 물어보기" button on trading chart and display response

## Testing
- `npm run build` in `Client`
- `npm test` in `Server` *(fails: Private endpoints require api and private keys set)*

------
https://chatgpt.com/codex/tasks/task_e_68888f4de44883268094edd8bbb7cf79