### PR TITLE
Fetch real klines only

### DIFF
--- a/Client/lib/bybit-client.ts
+++ b/Client/lib/bybit-client.ts
@@ -103,6 +103,8 @@ export class BybitService {
     interval?: string
     limit?: number
     category?: string
+    start?: number
+    end?: number
   }) {
 
     const query = new URLSearchParams({
@@ -111,6 +113,8 @@ export class BybitService {
       limit: (params.limit || 200).toString(),
       category: params.category || 'linear',
     })
+    if (params.start) query.set('start', params.start.toString())
+    if (params.end) query.set('end', params.end.toString())
 
     const res = await fetch(`${SERVER_URL}/api/klines?${query.toString()}`)
     if (!res.ok) {

--- a/Server/src/server.js
+++ b/Server/src/server.js
@@ -21,12 +21,16 @@ app.get('/api/klines', async (req, res) => {
       interval = '1',
       limit = '200',
       category = 'linear',
+      start,
+      end,
     } = req.query;
     const result = await restClient.getKline({
       category,
       symbol,
       interval: interval.toString(),
       limit: parseInt(limit, 10),
+      ...(start ? { start: parseInt(start, 10) } : {}),
+      ...(end ? { end: parseInt(end, 10) } : {}),
     });
     res.json(result);
   } catch (err) {


### PR DESCRIPTION
## Summary
- remove simulation fallback for klines and ticker data
- poll server endpoints for market data in all modes
- fetch klines before rendering chart and display loading state

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888adf85c1c832694ceb89ad45c73a0