### PR TITLE
Update trading mode configuration

### DIFF
--- a/Client/components/enhanced-live-trading.tsx
+++ b/Client/components/enhanced-live-trading.tsx
@@ -27,7 +27,7 @@ export function EnhancedLiveTrading() {
   const {
     selectedSymbol,
     tickers,
-    isSimulationMode,
+    isTestnet,
     isConnected,
     error,
     setSelectedSymbol,
@@ -118,7 +118,7 @@ export function EnhancedLiveTrading() {
         <div className="flex items-center gap-2">
           {isConnected ? <Wifi className="h-4 w-4" /> : <WifiOff className="h-4 w-4" />}
           <span>
-            {isConnected ? "실시간 데이터 연결됨" : "연결 끊어짐"}({isSimulationMode ? "시뮬레이션" : "실제 거래"} 모드)
+            {isConnected ? "실시간 데이터 연결됨" : "연결 끊어짐"}({isTestnet ? "테스트 거래" : "실제 거래"})
           </span>
         </div>
       </Alert>

--- a/Client/components/enhanced-position-manager.tsx
+++ b/Client/components/enhanced-position-manager.tsx
@@ -32,7 +32,7 @@ interface Position {
 }
 
 export function EnhancedPositionManager() {
-  const { positions, isSimulationMode, refreshAccountData } = useTradingStore()
+  const { positions, isTestnet, refreshAccountData } = useTradingStore()
   const [editingPosition, setEditingPosition] = useState<Position | null>(null)
   const [newStopLoss, setNewStopLoss] = useState("")
   const [newTakeProfit, setNewTakeProfit] = useState("")
@@ -114,8 +114,8 @@ export function EnhancedPositionManager() {
           <div>
             <CardTitle className="flex items-center gap-2">
               보유 포지션
-              <Badge variant={isSimulationMode ? "secondary" : "default"}>
-                {isSimulationMode ? "시뮬레이션" : "실제"}
+              <Badge variant={isTestnet ? "secondary" : "default"}>
+                {isTestnet ? "테스트넷" : "메인넷"}
               </Badge>
             </CardTitle>
             <CardDescription>현재 보유 중인 포지션을 실시간으로 관리하세요</CardDescription>

--- a/Client/components/enhanced-trading-chart.tsx
+++ b/Client/components/enhanced-trading-chart.tsx
@@ -114,7 +114,7 @@ interface EnhancedTradingChartProps {
 }
 
 export function EnhancedTradingChart({ symbol }: EnhancedTradingChartProps) {
-  const { tickers, isSimulationMode } = useTradingStore();
+  const { tickers, isTestnet } = useTradingStore();
   const [chartData, setChartData] = useState<ChartData[]>([]);
   const [timeframe, setTimeframe] = useState("1h");
   const [chartType, setChartType] = useState<"candlestick" | "line">(
@@ -451,8 +451,8 @@ export function EnhancedTradingChart({ symbol }: EnhancedTradingChartProps) {
           <div className="flex items-center gap-4">
             <CardTitle className="flex items-center gap-2">
               {symbol} 차트
-              <Badge variant={isSimulationMode ? "secondary" : "default"}>
-                {isSimulationMode ? "시뮬레이션" : "실시간"}
+              <Badge variant={isTestnet ? "secondary" : "default"}>
+                {isTestnet ? "테스트넷" : "메인넷"}
               </Badge>
             </CardTitle>
             {currentPrice > 0 && (

--- a/Client/components/real-time-order-book.tsx
+++ b/Client/components/real-time-order-book.tsx
@@ -16,7 +16,7 @@ interface RealTimeOrderBookProps {
 }
 
 export function RealTimeOrderBook({ symbol }: RealTimeOrderBookProps) {
-  const { orderbooks, isSimulationMode } = useTradingStore()
+  const { orderbooks, isTestnet } = useTradingStore()
   const [asks, setAsks] = useState<OrderBookEntry[]>([])
   const [bids, setBids] = useState<OrderBookEntry[]>([])
   const [spread, setSpread] = useState(0)
@@ -62,8 +62,8 @@ export function RealTimeOrderBook({ symbol }: RealTimeOrderBookProps) {
         <div className="flex justify-between items-center">
           <CardTitle className="text-sm">호가창</CardTitle>
           <div className="flex items-center gap-2">
-            <Badge variant={isSimulationMode ? "secondary" : "default"}>
-              {isSimulationMode ? "시뮬레이션" : "실시간"}
+            <Badge variant={isTestnet ? "secondary" : "default"}>
+              {isTestnet ? "테스트넷" : "메인넷"}
             </Badge>
             {spread > 0 && <Badge variant="outline">스프레드: ${spread.toFixed(2)}</Badge>}
           </div>

--- a/Server/src/server.js
+++ b/Server/src/server.js
@@ -8,9 +8,24 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
-const restClient = new RestClientV5({
+let restClient = new RestClientV5({
   key: process.env.BYBIT_API_KEY,
   secret: process.env.BYBIT_API_SECRET,
+  testnet: process.env.BYBIT_TESTNET === 'true',
+});
+
+function initRestClient({ apiKey, apiSecret, testnet }) {
+  restClient = new RestClientV5({
+    key: apiKey,
+    secret: apiSecret,
+    testnet,
+  });
+}
+
+// Initialize with environment variables on startup
+initRestClient({
+  apiKey: process.env.BYBIT_API_KEY,
+  apiSecret: process.env.BYBIT_API_SECRET,
   testnet: process.env.BYBIT_TESTNET === 'true',
 });
 
@@ -121,6 +136,21 @@ app.post('/api/validate', async (req, res) => {
   } catch (err) {
     console.log('API credential validation failed:', err.message);
     res.status(400).json({ valid: false, error: err.message });
+  }
+});
+
+app.post('/api/set-credentials', (req, res) => {
+  const { apiKey, apiSecret, testnet } = req.body;
+  try {
+    initRestClient({
+      apiKey,
+      apiSecret,
+      testnet: testnet === true || testnet === 'true',
+    });
+    res.json({ success: true });
+  } catch (err) {
+    console.error('Failed to set credentials:', err);
+    res.status(500).json({ error: err.message });
   }
 });
 


### PR DESCRIPTION
## Summary
- remove old simulation mode in favor of testnet/mainnet toggle
- store separate API keys for test and live trading
- allow toggling trading mode and updating credentials
- add API key issue button that links to testnet or mainnet
- update server to accept credential updates at runtime

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888fb85b2f88326a29cc9768bfb6e4e