### PR TITLE
Fix candlestick chart time ordering

### DIFF
--- a/Client/components/enhanced-trading-chart.tsx
+++ b/Client/components/enhanced-trading-chart.tsx
@@ -256,6 +256,7 @@ export function EnhancedTradingChart({ symbol }: EnhancedTradingChartProps) {
           } else {
             updated.push(newItem)
           }
+          updated.sort((a, b) => a.timestamp - b.timestamp)
           calculateIndicators(updated)
           return updated.slice(-1000)
         })
@@ -289,7 +290,8 @@ export function EnhancedTradingChart({ symbol }: EnhancedTradingChartProps) {
 
   const MainChart = ({ data }: { data: ChartData[] }) => {
     if (chartType === "candlestick") {
-      const candles = data.map((d) => ({
+      const sorted = [...data].sort((a, b) => a.timestamp - b.timestamp);
+      const candles = sorted.map((d) => ({
         time: d.timestamp / 1000 as any,
         open: d.open,
         high: d.high,

--- a/Client/components/lightweight-candlestick-chart.tsx
+++ b/Client/components/lightweight-candlestick-chart.tsx
@@ -83,16 +83,18 @@ export function LightweightCandlestickChart({ data }: Props) {
       }
     }
 
+    const sorted = [...data].sort((a, b) => Number(a.time) - Number(b.time));
+
     if (lengthRef.current === 0) {
-      seriesRef.current.setData(data);
-    } else if (data.length >= lengthRef.current) {
-      const last = data[data.length - 1];
+      seriesRef.current.setData(sorted);
+    } else if (sorted.length >= lengthRef.current) {
+      const last = sorted[sorted.length - 1];
       seriesRef.current.update(last);
     } else {
-      seriesRef.current.setData(data);
+      seriesRef.current.setData(sorted);
     }
     chartRef.current?.timeScale().scrollToRealTime();
-    lengthRef.current = data.length;
+    lengthRef.current = sorted.length;
   }, [data]);
 
   useEffect(() => {

--- a/Client/components/websocket-candlestick-chart.tsx
+++ b/Client/components/websocket-candlestick-chart.tsx
@@ -78,6 +78,7 @@ export function WebsocketCandlestickChart({ symbol, timeframe = "1m" }: Props) {
               } else {
                 updated.push(newItem)
               }
+              updated.sort((a, b) => Number(a.time) - Number(b.time))
               return updated.slice(-1000)
             })
           }


### PR DESCRIPTION
## Summary
- maintain chart data in chronological order for live updates
- sort candles before rendering candlestick chart
- ensure LightweightCandlestickChart sorts incoming data

## Testing
- `npm install --legacy-peer-deps`
- `CI=1 npm run lint` *(fails: prompts to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_6889004533f483268d8a8f047c8a7bc2