### PR TITLE
Simplify chart to basic candlestick view

### DIFF
--- a/Client/components/basic-candlestick-chart.tsx
+++ b/Client/components/basic-candlestick-chart.tsx
@@ -105,13 +105,17 @@ export function BasicCandlestickChart({ symbol }: Props) {
             close: Number(k[4]),
           }));
           combined = [...chunk, ...combined];
-          start = Number(list[0][0]) - msMap[timeframe] * 200;
+          start = Number(list[0][0]) - msMap[timeframe] * 200 - 1;
         } catch (err) {
           console.error("Failed to fetch klines", err);
           break;
         }
       }
       if (!cancelled) {
+        combined.sort((a, b) => Number(a.time) - Number(b.time));
+        combined = combined.filter(
+          (c, i, arr) => i === 0 || c.time !== arr[i - 1].time,
+        );
         setCandles(combined);
         unsub = bybitService.subscribeToKlines(
           symbol,
@@ -136,7 +140,10 @@ export function BasicCandlestickChart({ symbol }: Props) {
                 updated.push(newItem);
               }
               updated.sort((a, b) => Number(a.time) - Number(b.time));
-              return updated.slice(-1000);
+              const dedup = updated.filter(
+                (c, i, arr) => i === 0 || c.time !== arr[i - 1].time,
+              );
+              return dedup.slice(-1000);
             });
           },
         );

--- a/Client/components/basic-candlestick-chart.tsx
+++ b/Client/components/basic-candlestick-chart.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { bybitService } from "@/lib/bybit-client";
+import { LightweightCandlestickChart, Candle } from "./lightweight-candlestick-chart";
+
+const intervalMap: Record<string, string> = {
+  "1m": "1",
+  "5m": "5",
+  "15m": "15",
+  "1h": "60",
+  "1d": "D",
+};
+
+const msMap: Record<string, number> = {
+  "1m": 60 * 1000,
+  "5m": 5 * 60 * 1000,
+  "15m": 15 * 60 * 1000,
+  "1h": 60 * 60 * 1000,
+  "1d": 24 * 60 * 60 * 1000,
+};
+
+interface Props {
+  symbol: string;
+}
+
+export function BasicCandlestickChart({ symbol }: Props) {
+  const [timeframe, setTimeframe] = useState("1m");
+  const [candles, setCandles] = useState<Candle[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let unsub: (() => void) | undefined;
+
+    const fetchData = async () => {
+      let start: number | undefined;
+      let combined: Candle[] = [];
+      for (let i = 0; i < 5; i++) {
+        try {
+          const list = await bybitService.getKlines({
+            symbol,
+            interval: intervalMap[timeframe] || "1",
+            limit: 200,
+            category: "linear",
+            start,
+          });
+          if (!list.length) break;
+          list.sort((a: any, b: any) => Number(a[0]) - Number(b[0]));
+          const chunk: Candle[] = list.map((k: any) => ({
+            time: Number(k[0]) / 1000 as any,
+            open: Number(k[1]),
+            high: Number(k[2]),
+            low: Number(k[3]),
+            close: Number(k[4]),
+          }));
+          combined = [...chunk, ...combined];
+          start = Number(list[0][0]) - msMap[timeframe] * 200;
+        } catch (err) {
+          console.error("Failed to fetch klines", err);
+          break;
+        }
+      }
+      if (!cancelled) {
+        setCandles(combined);
+        unsub = bybitService.subscribeToKlines(
+          symbol,
+          intervalMap[timeframe] || "1",
+          (k) => {
+            setCandles((prev) => {
+              const ts = k.start < 1e12 ? k.start * 1000 : k.start;
+              const newItem: Candle = {
+                time: ts / 1000 as any,
+                open: k.open,
+                high: k.high,
+                low: k.low,
+                close: k.close,
+              };
+              const updated = [...prev];
+              if (updated.length && updated[updated.length - 1].time === newItem.time) {
+                updated[updated.length - 1] = newItem;
+              } else {
+                updated.push(newItem);
+              }
+              updated.sort((a, b) => Number(a.time) - Number(b.time));
+              return updated.slice(-1000);
+            });
+          }
+        );
+      }
+    };
+
+    fetchData();
+
+    return () => {
+      cancelled = true;
+      unsub?.();
+    };
+  }, [symbol, timeframe]);
+
+  return (
+    <div className="space-y-2">
+      <Tabs value={timeframe} onValueChange={setTimeframe} className="mb-2">
+        <TabsList>
+          <TabsTrigger value="1m">1분</TabsTrigger>
+          <TabsTrigger value="5m">5분</TabsTrigger>
+          <TabsTrigger value="15m">15분</TabsTrigger>
+          <TabsTrigger value="1h">1시간</TabsTrigger>
+          <TabsTrigger value="1d">1일</TabsTrigger>
+        </TabsList>
+      </Tabs>
+      <LightweightCandlestickChart data={candles} />
+    </div>
+  );
+}
+

--- a/Client/components/enhanced-live-trading.tsx
+++ b/Client/components/enhanced-live-trading.tsx
@@ -11,7 +11,7 @@ import { Badge } from "@/components/ui/badge"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { useTradingStore } from "@/lib/trading-store"
 import { bybitService } from "@/lib/bybit-client"
-import { EnhancedTradingChart } from "@/components/enhanced-trading-chart"
+import { BasicCandlestickChart } from "@/components/basic-candlestick-chart"
 import { RealTimeOrderBook } from "@/components/real-time-order-book"
 import { EnhancedPositionManager } from "@/components/enhanced-position-manager"
 import { TrendingUp, TrendingDown, AlertTriangle, Wifi, WifiOff } from "lucide-react"
@@ -202,7 +202,7 @@ export function EnhancedLiveTrading() {
       <div className="grid grid-cols-1 xl:grid-cols-4 gap-6">
         {/* Enhanced Chart */}
         <div className="xl:col-span-3">
-          <EnhancedTradingChart symbol={selectedSymbol} />
+          <BasicCandlestickChart symbol={selectedSymbol} />
         </div>
 
         {/* Enhanced Order Panel */}

--- a/Client/components/lightweight-candlestick-chart.tsx
+++ b/Client/components/lightweight-candlestick-chart.tsx
@@ -102,15 +102,7 @@ export function LightweightCandlestickChart({ data }: Props) {
     }
 
     const sorted = [...data].sort((a, b) => Number(a.time) - Number(b.time));
-
-    if (lengthRef.current === 0) {
-      seriesRef.current.setData(sorted);
-    } else if (sorted.length >= lengthRef.current) {
-      const last = sorted[sorted.length - 1];
-      seriesRef.current.update(last);
-    } else {
-      seriesRef.current.setData(sorted);
-    }
+    seriesRef.current.setData(sorted);
     chartRef.current?.timeScale().scrollToRealTime();
     lengthRef.current = sorted.length;
   }, [data]);

--- a/Client/components/websocket-candlestick-chart.tsx
+++ b/Client/components/websocket-candlestick-chart.tsx
@@ -51,13 +51,15 @@ export function WebsocketCandlestickChart({ symbol, timeframe = "1m" }: Props) {
             close: Number(k[4]),
           }))
           combined = [...chunk, ...combined]
-          start = Number(list[0][0]) - msMap[timeframe] * 200
+          start = Number(list[0][0]) - msMap[timeframe] * 200 - 1
         } catch (err) {
           console.error("Failed to fetch klines", err)
           break
         }
       }
       if (!cancelled) {
+        combined.sort((a, b) => Number(a.time) - Number(b.time))
+        combined = combined.filter((c, i, arr) => i === 0 || c.time !== arr[i - 1].time)
         setCandles(combined)
         unsub = bybitService.subscribeToKlines(
           symbol,
@@ -79,7 +81,8 @@ export function WebsocketCandlestickChart({ symbol, timeframe = "1m" }: Props) {
                 updated.push(newItem)
               }
               updated.sort((a, b) => Number(a.time) - Number(b.time))
-              return updated.slice(-1000)
+              const dedup = updated.filter((c, i, arr) => i === 0 || c.time !== arr[i - 1].time)
+              return dedup.slice(-1000)
             })
           }
         )


### PR DESCRIPTION
## Summary
- add BasicCandlestickChart component using lightweight-charts
- enable Ctrl+wheel zoom and disable chart animations
- comment out crosshair hover overlay
- replace EnhancedTradingChart usage with BasicCandlestickChart

## Testing
- `npm install --legacy-peer-deps` *(fails: interactive eslint prompt)*


------
https://chatgpt.com/codex/tasks/task_e_68899060464c83269070c6bc46ee1891