### PR TITLE
Enhance order placement UI

### DIFF
--- a/Server/src/server.js
+++ b/Server/src/server.js
@@ -168,7 +168,20 @@ app.post('/api/set-credentials', (req, res) => {
 
 app.post('/api/order', async (req, res) => {
   try {
-    const { symbol, side, orderType = 'Market', qty, price, leverage, positionIdx } = req.body;
+    const {
+      symbol,
+      side,
+      orderType = 'Market',
+      qty,
+      price,
+      leverage,
+      positionIdx,
+      triggerPrice,
+      triggerBy,
+      takeProfit,
+      stopLoss,
+      timeInForce,
+    } = req.body;
 
     if (leverage) {
       await restClient.setLeverage({
@@ -185,7 +198,12 @@ app.post('/api/order', async (req, res) => {
       side,
       orderType,
       qty: qty.toString(),
-      price,
+      ...(price ? { price } : {}),
+      ...(triggerPrice ? { triggerPrice } : {}),
+      ...(triggerBy ? { triggerBy } : {}),
+      ...(takeProfit ? { takeProfit } : {}),
+      ...(stopLoss ? { stopLoss } : {}),
+      ...(timeInForce ? { timeInForce } : {}),
       positionIdx: positionIdx ?? 0,
     });
     res.json(result);


### PR DESCRIPTION
## Summary
- consolidate order side into position dropdown
- add conditional order inputs and leverage options
- support take profit and stop loss with toggle
- allow time-in-force/post-only options
- expose new order parameters on server

## Testing
- `npm test` *(fails: Private endpoints require api keys)*
- `npm run build` in Client *(fails: next not found due to missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_688a553a1e948326b64a0dd8688df5af