### PR TITLE
feat: add canvas candlestick chart

### DIFF
--- a/Client/components/candlestick-chart.tsx
+++ b/Client/components/candlestick-chart.tsx
@@ -110,7 +110,7 @@ export function CandlestickChart({ data, width = 600, height = 300 }: Props) {
 
     const onWheel = (e: WheelEvent) => {
       e.preventDefault()
-      setZoom((z) => Math.min(3, Math.max(0.5, z - e.deltaY * 0.001)))
+      setZoom((z) => Math.min(100, Math.max(0.5, z - e.deltaY * 0.005)))
     }
     const onMove = (e: MouseEvent) => {
       const rect = canvas.getBoundingClientRect()

--- a/Client/components/candlestick-chart.tsx
+++ b/Client/components/candlestick-chart.tsx
@@ -1,0 +1,103 @@
+"use client"
+
+import { useRef, useEffect } from "react"
+
+export interface Candle {
+  time: number
+  open: number
+  high: number
+  low: number
+  close: number
+  volume?: number
+}
+
+interface Props {
+  data: Candle[]
+  width?: number
+  height?: number
+}
+
+export function CandlestickChart({ data, width = 800, height = 400 }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas || !data.length) return
+
+    const ctx = canvas.getContext("2d")
+    if (!ctx) return
+
+    ctx.clearRect(0, 0, width, height)
+
+    // price range
+    const prices = data.flatMap(d => [d.high, d.low])
+    const minPrice = Math.min(...prices)
+    const maxPrice = Math.max(...prices)
+    const priceRange = maxPrice - minPrice || 1
+
+    const candleWidth = (width - 100) / data.length
+    const chartHeight = height - 80
+
+    // grid
+    ctx.strokeStyle = "#2a2a2a"
+    ctx.lineWidth = 1
+
+    for (let i = 0; i <= 10; i++) {
+      const y = 40 + (chartHeight / 10) * i
+      ctx.beginPath()
+      ctx.moveTo(50, y)
+      ctx.lineTo(width - 50, y)
+      ctx.stroke()
+    }
+
+    for (let i = 0; i <= 10; i++) {
+      const x = 50 + ((width - 100) / 10) * i
+      ctx.beginPath()
+      ctx.moveTo(x, 40)
+      ctx.lineTo(x, height - 40)
+      ctx.stroke()
+    }
+
+    // price labels
+    ctx.fillStyle = "#888"
+    ctx.font = "12px monospace"
+    ctx.textAlign = "right"
+    for (let i = 0; i <= 10; i++) {
+      const price = maxPrice - (priceRange / 10) * i
+      const y = 40 + (chartHeight / 10) * i
+      ctx.fillText(price.toFixed(0), 45, y + 4)
+    }
+
+    // candles
+    data.forEach((candle, index) => {
+      const x = 50 + index * candleWidth + candleWidth / 2
+      const openY = 40 + ((maxPrice - candle.open) / priceRange) * chartHeight
+      const closeY = 40 + ((maxPrice - candle.close) / priceRange) * chartHeight
+      const highY = 40 + ((maxPrice - candle.high) / priceRange) * chartHeight
+      const lowY = 40 + ((maxPrice - candle.low) / priceRange) * chartHeight
+      const isGreen = candle.close > candle.open
+
+      ctx.strokeStyle = isGreen ? "#00ff88" : "#ff4444"
+      ctx.lineWidth = 1
+      ctx.beginPath()
+      ctx.moveTo(x, highY)
+      ctx.lineTo(x, lowY)
+      ctx.stroke()
+
+      ctx.fillStyle = isGreen ? "#00ff88" : "#ff4444"
+      const bodyTop = Math.min(openY, closeY)
+      const bodyHeight = Math.abs(closeY - openY)
+      ctx.fillRect(x - candleWidth / 4, bodyTop, candleWidth / 2, Math.max(bodyHeight, 1))
+    })
+  }, [data, width, height])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={width}
+      height={height}
+      className="border border-gray-800 bg-gray-900 w-full"
+    />
+  )
+}
+

--- a/Client/components/enhanced-live-trading.tsx
+++ b/Client/components/enhanced-live-trading.tsx
@@ -11,10 +11,10 @@ import { Badge } from "@/components/ui/badge"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { useTradingStore } from "@/lib/trading-store"
 import { bybitService } from "@/lib/bybit-client"
-import { EnhancedTradingChart } from "@/components/enhanced-trading-chart"
+import { WebsocketCandlestickChart } from "@/components/websocket-candlestick-chart"
 import { RealTimeOrderBook } from "@/components/real-time-order-book"
 import { EnhancedPositionManager } from "@/components/enhanced-position-manager"
-import { TrendingUp, TrendingDown, AlertTriangle, Wifi, WifiOff } from "lucide-react"
+import { TrendingUp, TrendingDown, AlertTriangle, Wifi, WifiOff, BarChart3 } from "lucide-react"
 
 const SUPPORTED_SYMBOLS = [
   { symbol: "BTCUSDT", name: "Bitcoin" },
@@ -47,6 +47,9 @@ export function EnhancedLiveTrading() {
   const [leverage, setLeverage] = useState("1")
   const [positionType, setPositionType] = useState<"long" | "short">("long")
   const [isPlacingOrder, setIsPlacingOrder] = useState(false)
+  const [timeframe, setTimeframe] = useState<
+    "1m" | "5m" | "15m" | "1h" | "4h" | "1d"
+  >("1m")
 
   // Subscribe to real-time data
   useEffect(() => {
@@ -214,9 +217,43 @@ export function EnhancedLiveTrading() {
       </div>
 
       <div className="grid grid-cols-1 xl:grid-cols-4 gap-6">
-        {/* Enhanced Chart */}
+        {/* Candlestick Chart */}
         <div className="xl:col-span-3">
-          <EnhancedTradingChart symbol={selectedSymbol} />
+          <Card className="bg-gray-900 border-gray-800">
+            <CardHeader>
+              <div className="flex justify-between items-center">
+                <CardTitle className="flex items-center space-x-2">
+                  <BarChart3 className="w-5 h-5" />
+                  <span>{selectedSymbol} Perpetual</span>
+                </CardTitle>
+                <div className="flex space-x-2">
+                  {[
+                    "1m",
+                    "5m",
+                    "15m",
+                    "1h",
+                    "4h",
+                    "1d",
+                  ].map((tf) => (
+                    <Button
+                      key={tf}
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setTimeframe(tf as any)}
+                    >
+                      {tf}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <WebsocketCandlestickChart
+                symbol={selectedSymbol}
+                timeframe={timeframe}
+              />
+            </CardContent>
+          </Card>
         </div>
 
         {/* Enhanced Order Panel */}


### PR DESCRIPTION
## Summary
- add canvas-based candlestick chart component
- stream Bybit data into candlestick chart with extended timeframes
- embed new chart in live trading view with timeframe controls

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompts for ESLint config)
- `npm run build` (fails: Module not found: Can't resolve './_components/dashboard')

------
https://chatgpt.com/codex/tasks/task_e_688f60a01eb08326906b9e65a3c6e612