### PR TITLE
feat: add TP/SL order support

### DIFF
--- a/Client/components/enhanced-live-trading.tsx
+++ b/Client/components/enhanced-live-trading.tsx
@@ -61,6 +61,7 @@ export function EnhancedLiveTrading() {
   >("1m")
   const [geminiAnswer, setGeminiAnswer] = useState<string | null>(null)
   const [isAsking, setIsAsking] = useState(false)
+  const [orderMessage, setOrderMessage] = useState<string | null>(null)
 
   const side = positionType === "long" ? "Buy" : "Sell"
 
@@ -178,6 +179,7 @@ export function EnhancedLiveTrading() {
 
     setIsPlacingOrder(true)
     setError(null)
+    setOrderMessage(null)
 
     try {
       const orderParams = {
@@ -192,7 +194,7 @@ export function EnhancedLiveTrading() {
         stopLoss: stopLoss || undefined,
       }
 
-      await placeOrder(orderParams)
+      const result = await placeOrder(orderParams)
 
       // Reset form
       setAmount("")
@@ -200,10 +202,15 @@ export function EnhancedLiveTrading() {
       setTakeProfit("")
       setStopLoss("")
 
-      // Show success message
-      setError(null)
-    } catch (error) {
+      if (result?.success) {
+        setOrderMessage("주문이 완료되었습니다")
+        setError(null)
+      } else {
+        setError("주문에 실패했습니다")
+      }
+    } catch (error: any) {
       console.error("Order placement failed:", error)
+      setError(error?.message || "주문에 실패했습니다")
     } finally {
       setIsPlacingOrder(false)
     }
@@ -474,7 +481,12 @@ export function EnhancedLiveTrading() {
                 </Alert>
               )}
 
-              {/* Error Display */}
+              {/* Order Result Messages */}
+              {orderMessage && (
+                <Alert>
+                  <AlertDescription>{orderMessage}</AlertDescription>
+                </Alert>
+              )}
               {error && (
                 <Alert variant="destructive">
                   <AlertTriangle className="h-4 w-4" />

--- a/Client/components/enhanced-live-trading.tsx
+++ b/Client/components/enhanced-live-trading.tsx
@@ -189,7 +189,6 @@ export function EnhancedLiveTrading() {
         qty: amount,
         price: orderType === "Market" ? undefined : price,
         leverage: Number.parseInt(leverage),
-        positionIdx: positionType === "long" ? 1 : 2,
         takeProfit: takeProfit || undefined,
         stopLoss: stopLoss || undefined,
       }

--- a/Client/components/enhanced-live-trading.tsx
+++ b/Client/components/enhanced-live-trading.tsx
@@ -6,7 +6,6 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Badge } from "@/components/ui/badge"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { useTradingStore } from "@/lib/trading-store"
@@ -50,17 +49,20 @@ export function EnhancedLiveTrading() {
   } = useTradingStore()
 
   const [orderType, setOrderType] = useState<"Market" | "Limit">("Limit")
-  const [side, setSide] = useState<"Buy" | "Sell">("Buy")
   const [amount, setAmount] = useState("")
   const [price, setPrice] = useState("")
   const [leverage, setLeverage] = useState("1")
   const [positionType, setPositionType] = useState<"long" | "short">("long")
   const [isPlacingOrder, setIsPlacingOrder] = useState(false)
+  const [takeProfit, setTakeProfit] = useState("")
+  const [stopLoss, setStopLoss] = useState("")
   const [timeframe, setTimeframe] = useState<
     "1m" | "5m" | "15m" | "1h" | "4h" | "1d"
   >("1m")
   const [geminiAnswer, setGeminiAnswer] = useState<string | null>(null)
   const [isAsking, setIsAsking] = useState(false)
+
+  const side = positionType === "long" ? "Buy" : "Sell"
 
   // Subscribe to real-time data
   useEffect(() => {
@@ -186,6 +188,8 @@ export function EnhancedLiveTrading() {
         price: orderType === "Market" ? undefined : price,
         leverage: Number.parseInt(leverage),
         positionIdx: positionType === "long" ? 1 : 2,
+        takeProfit: takeProfit || undefined,
+        stopLoss: stopLoss || undefined,
       }
 
       await placeOrder(orderParams)
@@ -193,6 +197,8 @@ export function EnhancedLiveTrading() {
       // Reset form
       setAmount("")
       setPrice("")
+      setTakeProfit("")
+      setStopLoss("")
 
       // Show success message
       setError(null)
@@ -323,24 +329,13 @@ export function EnhancedLiveTrading() {
               <CardDescription>
                 {SUPPORTED_SYMBOLS.find((s) => s.symbol === selectedSymbol)?.name}
                 {currentPrice > 0 && ` - $${currentPrice.toFixed(currentPrice > 1 ? 2 : 6)}`}
+                {` | 잔액: ${availableBalance.toFixed(2)} USDT`}
                 {positionQty > 0 && (
                   <> | 보유 수량: {positionQty.toFixed(4)}</>
                 )}
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
-              {/* Buy/Sell Tabs */}
-              <Tabs value={side} onValueChange={(value) => setSide(value as "Buy" | "Sell")}>
-                <TabsList className="grid w-full grid-cols-2">
-                  <TabsTrigger value="Buy" className="text-green-600">
-                    매수
-                  </TabsTrigger>
-                  <TabsTrigger value="Sell" className="text-red-600">
-                    매도
-                  </TabsTrigger>
-                </TabsList>
-              </Tabs>
-
               {/* Position Type */}
               <div className="space-y-2">
                 <Label>포지션 타입</Label>
@@ -436,15 +431,39 @@ export function EnhancedLiveTrading() {
                 </div>
               </div>
 
+              {/* Take Profit & Stop Loss */}
+              <div className="space-y-2">
+                <Label>익절가 (Take Profit)</Label>
+                <Input
+                  type="number"
+                  placeholder="익절가 입력"
+                  value={takeProfit}
+                  onChange={(e) => setTakeProfit(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>손절가 (Stop Loss)</Label>
+                <Input
+                  type="number"
+                  placeholder="손절가 입력"
+                  value={stopLoss}
+                  onChange={(e) => setStopLoss(e.target.value)}
+                />
+              </div>
+
               {/* Order Button */}
               <Button
                 className={`w-full ${
-                  side === "Buy" ? "bg-green-600 hover:bg-green-700" : "bg-red-600 hover:bg-red-700"
+                  positionType === "long"
+                    ? "bg-green-600 hover:bg-green-700"
+                    : "bg-red-600 hover:bg-red-700"
                 }`}
                 onClick={handlePlaceOrder}
                 disabled={isPlacingOrder || !amount || (orderType === "Limit" && !price)}
               >
-                {isPlacingOrder ? "주문 중..." : `${side === "Buy" ? "매수" : "매도"} 주문`}
+                {isPlacingOrder
+                  ? "주문 중..."
+                  : `${positionType === "long" ? "롱" : "숏"} 포지션 열기`}
               </Button>
 
               {/* Risk Warning */}

--- a/Client/lib/bybit-client.ts
+++ b/Client/lib/bybit-client.ts
@@ -169,6 +169,8 @@ export class BybitService {
     price?: string
     leverage?: number
     positionIdx?: number
+    takeProfit?: string
+    stopLoss?: string
   }) {
 
     try {

--- a/Client/lib/bybit-client.ts
+++ b/Client/lib/bybit-client.ts
@@ -138,7 +138,7 @@ export class BybitService {
         throw new Error(`Server error ${res.status}: ${message}`)
       }
       const data = await res.json()
-      return data.result
+      return data
     } catch (error) {
       console.error("Error fetching account balance:", error)
       throw error
@@ -184,7 +184,7 @@ export class BybitService {
         throw new Error(`Server error ${res.status}: ${message}`)
       }
       const data = await res.json()
-      return data.result
+      return data
     } catch (error) {
       console.error("Error placing order:", error)
       throw error

--- a/Server/src/server.js
+++ b/Server/src/server.js
@@ -168,7 +168,17 @@ app.post('/api/set-credentials', (req, res) => {
 
 app.post('/api/order', async (req, res) => {
   try {
-    const { symbol, side, orderType = 'Market', qty, price, leverage, positionIdx } = req.body;
+    const {
+      symbol,
+      side,
+      orderType = 'Market',
+      qty,
+      price,
+      leverage,
+      positionIdx,
+      takeProfit,
+      stopLoss,
+    } = req.body;
 
     if (leverage) {
       await restClient.setLeverage({
@@ -187,6 +197,8 @@ app.post('/api/order', async (req, res) => {
       qty: qty.toString(),
       price,
       positionIdx: positionIdx ?? 0,
+      ...(takeProfit ? { takeProfit, tpSlMode: 'Full' } : {}),
+      ...(stopLoss ? { stopLoss, tpSlMode: 'Full' } : {}),
     });
     res.json(result);
   } catch (err) {

--- a/Server/src/server.js
+++ b/Server/src/server.js
@@ -104,7 +104,9 @@ app.get('/api/orders', async (req, res) => {
   try {
     const result = await restClient.getActiveOrders({ category: 'linear' });
     const count = result?.result?.list?.length || 0;
-    console.log('Fetched', count, 'active orders');
+    if (count > 0) {
+      console.log('Fetched', count, 'active orders');
+    }
     res.json(result);
   } catch (err) {
     console.error('Error fetching orders:', err);
@@ -167,6 +169,7 @@ app.post('/api/set-credentials', (req, res) => {
 });
 
 app.post('/api/order', async (req, res) => {
+  console.log('Received order request:', req.body);
   try {
     const {
       symbol,
@@ -200,10 +203,12 @@ app.post('/api/order', async (req, res) => {
       ...(takeProfit ? { takeProfit, tpSlMode: 'Full' } : {}),
       ...(stopLoss ? { stopLoss, tpSlMode: 'Full' } : {}),
     });
-    res.json(result);
+
+    console.log('Order result:', result);
+    res.json({ success: true, result });
   } catch (err) {
     console.error('Error placing order:', err);
-    res.status(500).json({ error: err.message });
+    res.status(500).json({ success: false, error: err.message });
   }
 });
 


### PR DESCRIPTION
## Summary
- allow take profit / stop loss when placing orders
- remove buy/sell toggle in order panel and show balance
- forward TP/SL parameters to server for real Bybit trades

## Testing
- `npm test` (server) *(fails: Private endpoints require api and private keys set)*
- `npm run lint` (client) *(interactive ESLint prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6890c13d21e48326a1a4926afadb5beb